### PR TITLE
refactor the "Future of Python Packaging" to "The Work of PyPA"

### DIFF
--- a/source/future.rst
+++ b/source/future.rst
@@ -1,6 +1,6 @@
-==============================
-The Future of Python Packaging
-==============================
+================
+The Work of PyPA
+================
 
 
 The :ref:`distutils` cross-platform build and distribution system was added to
@@ -10,7 +10,7 @@ is almost 15 years old, which poses a variety of challenges to successful
 evolution.
 
 The current effort to improve the situation started when the ``packaging``
-library (also known as ``distutils2``) `failed to be accepted
+library (also known as ``distutils2``) `did not make it
 <https://mail.python.org/pipermail/python-dev/2012-June/120430.html>`_ into the
 standard library for Python 3.3.  That effort had spanned from 2009 to 2012.
 
@@ -57,7 +57,9 @@ How to help
   installation.  See the `The issue tracker for the problems in packaging
   <https://github.com/pypa/packaging-problems/issues>`_ maintained by
   :term:`PyPA <Python Packaging Authority (PyPA)>`.
-* Discuss :doc:`PEPs <peps>` and long terms plans at `distutils-sig
+* Submit Issues and PRs to the `PyPA PEP Development Repository
+  <https://github.com/pypa/interoperability-peps>`_
+* Discuss pretty much anything related to packaging at `distutils-sig
   <http://mail.python.org/mailman/listinfo/distutils-sig>`_.
 
 
@@ -95,68 +97,6 @@ regarding current and future efforts related to packaging.
   * `Nick Coghlan
     <http://python-notes.curiousefficiency.org/en/latest/pep_ideas/core_packaging_api.html>`__
 
-
-Major Todos
-===========
-
-Metadata 2.0
-------------
-
-`See the Metadata Open Issues
-<https://bitbucket.org/pypa/pypi-metadata-formats/issues?status=new&status=open&priority=blocker>`_
-
-* :ref:`PEP426: Metadata for Python Software Packages 2.0 <PEP426s>`
-* :ref:`PEP440: Version Identification and Dependency Specification <PEP440s>`
-* `PEP459: Standard Metadata Extensions for Python Software Packages
-  <http://legacy.python.org/dev/peps/pep-0459/>`_
-* `Wheel 1.1
-  <https://bitbucket.org/pypa/pypi-metadata-formats/issue/18/wheel-11>`_
-* `sdist 2.0
-  <https://bitbucket.org/pypa/pypi-metadata-formats/issue/20/sdist-20>`_
-* `PEP for common naming schemes
-  <https://bitbucket.org/pypa/pypi-metadata-formats/issue/23/common-filename-scheme>`_
-* `Installation Database 2.0 (replace PEP376)
-  <https://bitbucket.org/pypa/pypi-metadata-formats/issue/22/installation-database-2>`_
-
-
-PyPI Infrastructure
--------------------
-
-* Migration from the legacy PyPI server to :ref:`warehouse` (the preview is
-  available at https://warehouse.python.org/ running off the live PyPI data)
-* :ref:`PEP458 <PEP458s>`: An integration of PyPI with the "The Update Framework (TUF)"
-* Improved PyPI upload API
-
-
-pip
----
-
-* An internal stable API for pip
-* Removal of older pip commands and options that aren't popular or well
-  maintained (`#906 <https://github.com/pypa/pip/issues/906>`_, `#1046
-  <https://github.com/pypa/pip/issues/1046>`_)
-* :ref:`pip` needs a `real dependency resolver
-  <https://github.com/pypa/pip/issues/988>`_
-
-
-Docs and Community
-------------------
-
-* Refactor the :ref:`virtualenv`, :ref:`setuptools`, and :ref:`wheel` docs to
-  be consistent with the `"PyPA Standard Docs Template"
-  <https://gist.github.com/qwcode/8431828>`_
-* Document pip's (and more generally pypa's) deprecation policy (`Issue 1611
-  <https://github.com/pypa/pip/issues/1611>`_)
-* A general release email list for all Pypa projects?
-
-
-More PEPs
----------
-
-* A `"MetaBuild" <http://www.python.org/dev/peps/pep-0426/#metabuild-system>`_
-  PEP that would allow projects to specify alternative build systems
-  (i.e. something other than setuptools).
-* `Wheel 2.0 <https://bitbucket.org/pypa/pypi-metadata-formats/issue/19/wheel-20>`_
 
 ----
 


### PR DESCRIPTION
it's ok to list some general goals here, but let's let the literal future just be defined by the work as it plays out in https://github.com/pypa/interoperability-peps