### PR TITLE
Define specification update process

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -21,6 +21,7 @@ For a user introduction to packaging, see the `Python Packaging User Guide
    :maxdepth: 1
 
    future
+   specifications
    roadmap
    help
    presentations

--- a/source/specifications.rst
+++ b/source/specifications.rst
@@ -1,0 +1,35 @@
+.. _`PyPA Specifications`:
+
+===================
+PyPA Specifications
+===================
+
+In addition to maintaining the default implementation of the Python packaging
+toolchain, the Python Packaging Authority is also responsible for maintaining
+the interoperability specifications used to define the interactions between
+those tools.
+
+Specification Process
+---------------------
+
+PyPA interoperability specifications are currently handled as Informational
+Python Enhancement Proposals in accordance with :pep:`1`.
+
+Whenever a new PEP is put forward on distutils-sig, any PyPA core
+reviewer that believes they are suitably experienced to make the final
+decision on that PEP may offer to serve as the BDFL's delegate (or
+"PEP czar") for that PEP. If their self-nomination is accepted by the
+other PyPA core reviewers, the lead PyPI maintainer and the lead
+CPython representative on distutils-sig, then they will have the
+authority to approve (or reject) that PEP.
+
+The current lead PyPI maintainer is Donald Stufft, while the current lead
+CPython representative on distutils-sig is Nick Coghlan.
+
+
+Active Specifications
+---------------------
+
+The currently active specifications are recorded as a part of the
+:ref:`Python Packaging User Guide <pypug:specifications>`.
+


### PR DESCRIPTION
This summary of the current PyPA specification update process was
previously only captured in distutils-sig archives.