### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/source/history.rst
+++ b/source/history.rst
@@ -117,7 +117,7 @@ development of :ref:`distutils`.
 
 .. _distutils-sig: http://www.python.org/community/sigs/current/distutils-sig/
 .. _catalog-sig: https://mail.python.org/mailman/listinfo/catalog-sig
-.. _`Python Packaging User Guide`: https://python-packaging-user-guide.readthedocs.org/en/latest/
+.. _`Python Packaging User Guide`: https://python-packaging-user-guide.readthedocs.io/en/latest/
 .. _PEP241: http://www.python.org/dev/peps/pep-0241
 .. _PEP314: http://www.python.org/dev/peps/pep-0314
 .. _PEP301: http://www.python.org/dev/peps/pep-0301


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
