### PR TITLE
Update spec process to match reality

### DIFF
--- a/source/specifications.rst
+++ b/source/specifications.rst
@@ -12,9 +12,17 @@ those tools.
 Active Specifications
 ---------------------
 
+Interoperability specifications maintained by the Python Packaging Authority
+are tracked as Informational Python Enhancement Proposals in accordance
+with :pep:`1`.
+
 The currently active specifications are recorded in the
 :ref:`PyPA Specifications <pypug:specifications>` section of the
 Python Packaging User Guide.
+
+This section may also include clarifications, amendments and additional
+guidance for specification implementors in cases where the corresponding
+PEPs have yet to be updated appropriately.
 
 
 Specification Update Process
@@ -28,36 +36,25 @@ PyPA interoperability specifications are separated into two categories:
 For Package Distribution Metadata, the default responsible decision maker is
 the lead CPython representative on distutils-sig.
 
+The current lead CPython representative on distutils-sig is Nick Coghlan.
+
 For Package Index Interfaces, the default responsible decision maker is
 the lead maintainer for the `Python Package Index <https://pypi.org>`__.
 
-The current lead PyPI maintainer is Donald Stufft, while the current lead
-CPython representative on distutils-sig is Nick Coghlan.
+The current lead PyPI maintainer is Donald Stufft.
 
 
-Handling fixes and other minor updates
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Proposing new specifications
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Backwards compatible fixes and small enhancements to the specifications are
-handled by submitting pull requests to the specifications section of the guide.
-All enhancements proposed this way *must* be discussed
+Proposals for new interoperability specifications should be formulated and
+submitted as new Informational Python Enhancement Proposals in accordance
+with :pep:`1`.
 
-PyPA core reviewers are responsible for deciding which of these changes can
-just be accepted (e.g. fixing a typo), which need to be reviewed by the relevant
-responsible decision maker before being accepted, and which need to be escalated
-to the full Python Enhancement Proposal process.
-
-
-Handling new specifications and major updates
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Proposals for new interoperability specifications or major changes to existing
-ones should be formulated and submitted as Standards Track Python Enhancement
-Proposals in accordance with :pep:`1`.
-
-Such proposals must reference a PR against the PyPA Specifications section in
-the Python Packaging User Guide that adds the new specification as a separate
-file and updates the index of active specifications accordingly.
+Such proposals must be accompanied by a PR against the PyPA Specifications
+section in the Python Packaging User Guide that adds a new subsection defining
+the purpose of the new specification and the role it plays in the wider Python
+packaging ecosystem.
 
 The ``Discussions-To`` header in packaging related PEPs should be set to
 ``distutils-sig@python.org``.
@@ -75,31 +72,51 @@ Otherwise, the default BDFL-Delegate depends on the area the PEP affects:
 * Package Distribution Metadata: lead CPython representative on distutils-sig
 * Package Index Interfaces: lead PyPI maintainer
 
-Proposals that require backwards incompatible changes to existing
-interoperability specifications (and hence a new major version of the
-specification rather than in-place updates) are currently not permitted. If
-that policy is changed in the future, then some additional work will be needed
-to define stable URLs that reference the active version of affected
-specifications.
+
+Handling fixes and other minor updates
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The preferred approach to handling fixes and other minor updates adopted for
+all recent interoperability specifications is to submit an issue and/or pull
+request against the `official PEPs repo <https://github.com/python/peps>`_.
+
+All enhancements proposed this way *must* be discussed on distutils-sig prior
+to amending the PEP, and any changes made after PEP acceptance must be
+explicitly documented in a "Changes" section in the PEP itself. For example,
+see:
+
+* `Changes in PEP 440 <https://www.python.org/dev/peps/pep-0440/#summary-of-changes-to-pep-440>`_
+* `Changes in PEP 503 <https://www.python.org/dev/peps/pep-0503/#changes>`_
+
+PyPA core reviewers that are also PEP editos are responsible for deciding which
+of these changes can just be accepted (e.g. fixing a typo), which need to be
+reviewed by the relevant responsible decision maker before being accepted, and
+which need to be escalated to the full Python Enhancement Proposal process.
+
+One current exception to this policy is the core metadata specification in
+PEP 345, where additional fields and the selective superceding of various
+sections is documented directly in the specification section of the Python
+Packaging User Guide.
+
+.. With the definition and adoption of metadata 2.0 deferred indefinitely,
+   these changes should probably be rolled into a metadata 1.3 informational
+   PEP that follows the standard update policy described above
 
 
-Handling existing specifications maintained as Informational PEPs
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Handling major updates
+~~~~~~~~~~~~~~~~~~~~~~
 
-Historically, new interoperability specifications or major changes to existing
-ones were handled as Informational Python Enhancement Proposals in accordance
-with :pep:`1`. This proved problematic, as it meant the proposals were a mix
-of both the specification itself, as well as the rationale for the
-specification, which could make them difficult to read for tool implementors.
-It also meant that new revisions needed to either leave the original version
-active (requiring tool implementors to read both to get a clear view of what
-they needed to implement) or else duplicate the original content (making it
-harder to review just the changes to the specification).
+For package distribution metadata, proposals that require backwards
+incompatible changes to existing interoperability specifications for
+package distribution metadata (and hence a new major version of the
+specification rather than an in-place update) are currently not permitted.
 
-For these existing specifications, the maintenance process is as follows:
+This policy has been introduced based on historical experience that such
+incompatibilities lead to the community sticking with older versions of the
+metadata format indefinitely rather than upgrading to the revised format.
 
-* Fixes and other minor updates are handled as issues on the Python Packaging
-  User Guide, and PRs to the `official PEPs repo <https://github.com/python/peps>`_
-* If a major update is needed, then a Standards Track PEP should be written
-  that includes migrating the affected specification fully to the Python
-  Packaging User Guide based maintenance process as part of the proposal
+For package index interfaces, major updates are handled as either Process or
+Standards Track PEPs targeting the Python Package Index as the reference
+implemetation. All such PEPs that introduce backwards incompatible changes
+are required to define a suitable transition plan for affected software
+publishers and tool developers.

--- a/source/specifications.rst
+++ b/source/specifications.rst
@@ -9,11 +9,58 @@ toolchain, the Python Packaging Authority is also responsible for maintaining
 the interoperability specifications used to define the interactions between
 those tools.
 
-Specification Process
+Active Specifications
 ---------------------
 
-PyPA interoperability specifications are currently handled as Informational
-Python Enhancement Proposals in accordance with :pep:`1`.
+The currently active specifications are recorded in the
+:ref:`PyPA Specifications <pypug:specifications>` section of the
+Python Packaging User Guide.
+
+
+Specification Update Process
+----------------------------
+
+PyPA interoperability specifications are separated into two categories:
+
+* `Package Distribution Metadata <https://packaging.python.org/specifications/#package-distribution-metadata>`_
+* `Package Index Interfaces <https://packaging.python.org/specifications/#package-index-interfaces>`_
+
+For Package Distribution Metadata, the default responsible decision maker is
+the lead CPython representative on distutils-sig.
+
+For Package Index Interfaces, the default responsible decision maker is
+the lead maintainer for the `Python Package Index <https://pypi.org>`__.
+
+The current lead PyPI maintainer is Donald Stufft, while the current lead
+CPython representative on distutils-sig is Nick Coghlan.
+
+
+Handling fixes and other minor updates
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Backwards compatible fixes and small enhancements to the specifications are
+handled by submitting pull requests to the specifications section of the guide.
+All enhancements proposed this way *must* be discussed
+
+PyPA core reviewers are responsible for deciding which of these changes can
+just be accepted (e.g. fixing a typo), which need to be reviewed by the relevant
+responsible decision maker before being accepted, and which need to be escalated
+to the full Python Enhancement Proposal process.
+
+
+Handling new specifications and major updates
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Proposals for new interoperability specifications or major changes to existing
+ones should be formulated and submitted as Standards Track Python Enhancement
+Proposals in accordance with :pep:`1`.
+
+Such proposals must reference a PR against the PyPA Specifications section in
+the Python Packaging User Guide that adds the new specification as a separate
+file and updates the index of active specifications accordingly.
+
+The ``Discussions-To`` header in packaging related PEPs should be set to
+``distutils-sig@python.org``.
 
 Whenever a new PEP is put forward on distutils-sig, any PyPA core
 reviewer that believes they are suitably experienced to make the final
@@ -23,13 +70,36 @@ other PyPA core reviewers, the lead PyPI maintainer and the lead
 CPython representative on distutils-sig, then they will have the
 authority to approve (or reject) that PEP.
 
-The current lead PyPI maintainer is Donald Stufft, while the current lead
-CPython representative on distutils-sig is Nick Coghlan.
+Otherwise, the default BDFL-Delegate depends on the area the PEP affects:
+
+* Package Distribution Metadata: lead CPython representative on distutils-sig
+* Package Index Interfaces: lead PyPI maintainer
+
+Proposals that require backwards incompatible changes to existing
+interoperability specifications (and hence a new major version of the
+specification rather than in-place updates) are currently not permitted. If
+that policy is changed in the future, then some additional work will be needed
+to define stable URLs that reference the active version of affected
+specifications.
 
 
-Active Specifications
----------------------
+Handling existing specifications maintained as Informational PEPs
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The currently active specifications are recorded as a part of the
-:ref:`Python Packaging User Guide <pypug:specifications>`.
+Historically, new interoperability specifications or major changes to existing
+ones were handled as Informational Python Enhancement Proposals in accordance
+with :pep:`1`. This proved problematic, as it meant the proposals were a mix
+of both the specification itself, as well as the rationale for the
+specification, which could make them difficult to read for tool implementors.
+It also meant that new revisions needed to either leave the original version
+active (requiring tool implementors to read both to get a clear view of what
+they needed to implement) or else duplicate the original content (making it
+harder to review just the changes to the specification).
 
+For these existing specifications, the maintenance process is as follows:
+
+* Fixes and other minor updates are handled as issues on the Python Packaging
+  User Guide, and PRs to the `official PEPs repo <https://github.com/python/peps>`_
+* If a major update is needed, then a Standards Track PEP should be written
+  that includes migrating the affected specification fully to the Python
+  Packaging User Guide based maintenance process as part of the proposal

--- a/source/specifications.rst
+++ b/source/specifications.rst
@@ -88,19 +88,28 @@ see:
 * `Changes in PEP 440 <https://www.python.org/dev/peps/pep-0440/#summary-of-changes-to-pep-440>`_
 * `Changes in PEP 503 <https://www.python.org/dev/peps/pep-0503/#changes>`_
 
-PyPA core reviewers that are also PEP editos are responsible for deciding which
+PyPA core reviewers that are also PEP editors are responsible for deciding which
 of these changes can just be accepted (e.g. fixing a typo), which need to be
 reviewed by the relevant responsible decision maker before being accepted, and
 which need to be escalated to the full Python Enhancement Proposal process.
 
-One current exception to this policy is the core metadata specification in
-PEP 345, where additional fields and the selective superceding of various
+Current exceptions to this policy exist for:
+
+* the core metadata specification in PEP 345
+* the installed distributions metadata layout specification in PEP 376
+
+For historical reasons, these PEPs are currently maintained in a hybrid
+state where additional fields and the selective superceding of various
 sections is documented directly in the specification section of the Python
-Packaging User Guide.
+Packaging User Guide rather than being incorporated into the original PEP.
 
 .. With the definition and adoption of metadata 2.0 deferred indefinitely,
-   these changes should probably be rolled into a metadata 1.3 informational
-   PEP that follows the standard update policy described above
+   the PyPUG changes to PEP 345 should probably be rolled into a metadata 1.3
+   informational PEP that follows the standard update policy described above
+
+   Similarly, a new PEP could describe the installation metadata as actually
+   emitted by pip, rather than as originally proposed in PEP 376, without
+   needing to add anything new to it
 
 
 Handling major updates
@@ -117,6 +126,6 @@ metadata format indefinitely rather than upgrading to the revised format.
 
 For package index interfaces, major updates are handled as either Process or
 Standards Track PEPs targeting the Python Package Index as the reference
-implemetation. All such PEPs that introduce backwards incompatible changes
+implementation. All such PEPs that introduce backwards incompatible changes
 are required to define a suitable transition plan for affected software
 publishers and tool developers.


### PR DESCRIPTION
For a while now we've been allowing minor amendments to the
interoperability PEPs via the Python Packaging User Guide.

This PR updates the PyPA specifications process documentation
to match the way things are currently working in practice.