### PR TITLE
update links, copyright date, Sphinx requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-sphinx==1.6.2
+sphinx==1.8.5
 git+https://github.com/python/python-docs-theme.git#egg=python-docs-theme
 git+https://github.com/pypa/pypa-docs-theme.git#egg=pypa-docs-theme

--- a/source/conf.py
+++ b/source/conf.py
@@ -42,7 +42,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'PyPA'
-copyright = u'2014, PyPA'
+copyright = u'2019, PyPA'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/source/history.rst
+++ b/source/history.rst
@@ -4,6 +4,12 @@
 Packaging History
 =================
 
+2019
+----
+
+* `OTF grant for PyPI awarded to PSF`_, team began in March to focus
+  on security and accessibility improvements to Warehouse.
+
 2018
 ----
 
@@ -169,6 +175,7 @@ development of :ref:`distutils`.
 .. _`Python Packaging User Guide`: https://python-packaging-user-guide.readthedocs.io/en/latest/
 .. _distribute: https://pypi.org/pypi/distribute
 .. _`MOSS grant for PyPI`: https://pyfound.blogspot.com/2017/11/the-psf-awarded-moss-grant-pypi.html
+.. _`OTF grant for PyPI awarded to PSF`: https://pyfound.blogspot.com/2019/03/commencing-security-accessibility-and.html
 .. _`pip release notes`: https://pip.pypa.io/en/stable/news/
 
 ----

--- a/source/history.rst
+++ b/source/history.rst
@@ -167,7 +167,7 @@ development of :ref:`distutils`.
 .. _peep: https://pypi.org/project/peep/
 .. _`Fastly CDN enabled`: https://mail.python.org/pipermail/distutils-sig/2013-May/020848.html
 .. _`Python Packaging User Guide`: https://python-packaging-user-guide.readthedocs.io/en/latest/
-.. _distribute: https://pypi.python.org/pypi/distribute
+.. _distribute: https://pypi.org/pypi/distribute
 .. _`MOSS grant for PyPI`: https://pyfound.blogspot.com/2017/11/the-psf-awarded-moss-grant-pypi.html
 .. _`pip release notes`: https://pip.pypa.io/en/stable/news/
 

--- a/source/index.rst
+++ b/source/index.rst
@@ -6,10 +6,14 @@ Python Packaging Authority
 The Python Packaging Authority (PyPA) is a working group that maintains many of
 the relevant projects in Python packaging.
 
-They host projects on `GitHub <https://github.com/pypa>`_ and `Bitbucket
-<https://bitbucket.org/pypa>`_, and discuss issues on the `pypa-dev
-<https://groups.google.com/forum/#!forum/pypa-dev>`_ and `distutils-sig
-<http://mail.python.org/mailman/listinfo/distutils-sig>`_ mailing lists.
+They host projects on `GitHub <https://github.com/pypa>`_ and
+`Bitbucket <https://bitbucket.org/pypa>`_, and discuss issues in `the
+Packaging category on discuss.python.org
+<https://discuss.python.org/c/packaging>`_ and on the `pypa-dev
+<https://groups.google.com/forum/#!forum/pypa-dev>`_ and
+`distutils-sig
+<http://mail.python.org/mailman/listinfo/distutils-sig>`_ mailing
+lists.
 
 For a listing of their most important projects, see :ref:`the key projects list
 <pypug:pypa_projects>`.

--- a/source/roadmap.rst
+++ b/source/roadmap.rst
@@ -30,8 +30,8 @@ Metadata 2.0
 :Issues/PRs: `pypa/interoperability-peps/labels/PEP426
                  <https://github.com/pypa/interoperability-peps/labels/PEP426>`_
 
-:Status: `PEP426`_ is `in Deferred status
-         <https://www.python.org/dev/peps/pep-0426/#note-on-pep-deferral>`_,
+:Status: `PEP426`_ is `in Withdrawn status
+         <https://www.python.org/dev/peps/pep-0426/#note-on-pep-history>`_,
          and `PEP 566 (Metadata 1.3)
          <https://www.python.org/dev/peps/pep-0566/>`_ is a Draft
          introduced in December 2017.


### PR DESCRIPTION
Per distutils-sig discussions -- [1](https://mail.python.org/archives/list/distutils-sig@python.org/thread/VXXPZCVRLH27N46TR3P6IEOKIA47POCM/#MAKZVRIHJ7BIKP727KPEF6BOH54FS7IT) and [2](https://mail.python.org/archives/list/distutils-sig@python.org/thread/YDGSVFLTFYVXEJ3QFK655DTYI4VTHA3U/#F7IKOB42INCX75A3KFMVP22CHWFBQTZ5) -- pypa.io should point to the new Discourse forum.

Also updated various other links, Sphinx requirement + copyright date.

Fixes  #31.