### PR TITLE
Edit prose to be more user focused

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -3,8 +3,8 @@ Python Packaging Authority
 ==========================
 
 
-The Python Packaging Authority (PyPA) is a working group that maintains many of
-the relevant projects in Python packaging.
+The Python Packaging Authority (PyPA) is a working group that maintains a core
+set of projects used in Python packaging.
 
 .. **** CAREFUL HERE ****
 ..
@@ -21,8 +21,17 @@ such as `PyPI <https://pypi.org>`_, the Python Package Index. Click the logo bel
 
 .. **** END CAREFUL HERE ****
 
-They host projects on `GitHub <https://github.com/pypa>`_ and
-`Bitbucket <https://bitbucket.org/pypa>`_, and discuss issues in `the
+The PyPA publishes the `Python Packaging User Guide
+<https://packaging.python.org>`_ as the authoritative resource on how to
+package, publish, and install Python projects using current tools. The User
+Guide provides a user introduction to packaging and use of these
+tools. As a service to Python users who may need to package Python with other
+languages (a common example is scientific Python packages), the user guide also
+offers basic information and links to available third party packaging options
+(for example, `conda-forge <https://conda-forge.org/>`_).
+
+The PyPA hosts projects on `GitHub <https://github.com/pypa>`_ and
+`Bitbucket <https://bitbucket.org/pypa>`_, and discusses issues in `the
 Packaging category on discuss.python.org
 <https://discuss.python.org/c/packaging>`_ and on the `pypa-dev
 <https://groups.google.com/forum/#!forum/pypa-dev>`_ and
@@ -30,7 +39,7 @@ Packaging category on discuss.python.org
 <http://mail.python.org/mailman/listinfo/distutils-sig>`_ mailing
 lists.
 
-For a listing of their most important projects, see :ref:`the key projects list
+For a listing of PyPA's important projects, see :ref:`the key projects list
 <pypug:pypa_projects>`.
 
 For a user introduction to packaging, see the `Python Packaging User Guide


### PR DESCRIPTION
This PR provides more information for the end user on the role of the PyPA and highlights several purposes the [Python Packaging User Guide](https://packaging.python.org/) serves today. The goals of these edits are:
- to clarify in a firm, yet welcoming, tone what the PyPA is
- highlight the helpful Python Packaging User Guide
- inform users that the Python Packaging User Guide, as a community maintained guide, may include basic information and links to resources related to packaging a project that is a mix of Python and other languages.

Partially addresses https://github.com/pypa/packaging.python.org/issues/367

cc/ @dstufft