### PR TITLE
Add initial membership documentation

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -52,4 +52,5 @@ For a user introduction to packaging, see the `Python Packaging User Guide
    help
    presentations
    history
+   members
    code-of-conduct

--- a/source/members.rst
+++ b/source/members.rst
@@ -1,0 +1,77 @@
+.. _`PyPA Members, and how to join`:
+
+=============================
+PyPA Members, And How To Join
+=============================
+
+:Last Reviewed: 2020-06-08
+
+Historically, the PyPA has been a loose confederation of people
+and projects; the word "authority" in the name was meant to be
+a joke.
+
+.. _`Does not require membership`:
+
+Does not require membership
+---------------------------
+
+Anyone is welcome to (while following licensing terms) use PyPA projects.
+
+Anyone is welcome to (while following the PyPA's :ref:`Code of Conduct`)
+contribute patches, bug reports, feature requests, ideas, questions,
+answers, and similar information in our `GitHub organization`_ and
+`Bitbucket organization`_ repositories, and discuss issues and plans
+with us in `the Packaging category on discuss.python.org`_ and on `the
+distutils-sig mailing list`_.
+
+.. _`Project membership`:
+
+Project membership
+------------------
+
+The PyPA member projects are those listed within our `GitHub organization
+<https://github.com/pypa>`_ and `Bitbucket organization
+<https://bitbucket.org/pypa>`_.
+
+We currently do not have a codified process for inviting or accepting
+projects to be PyPA members. :pep:`609` is currently under discussion
+to formalize the process.
+
+In the interim, to request PyPA project membership, start a thread on
+`the Packaging category on discuss.python.org`_ or on `the
+distutils-sig mailing list`_ requesting PyPA project
+membership. Criteria include the project adopting the PyPA's
+:ref:`Code of Conduct` and the project being relevant to Python
+packaging, as determined by existing members of PyPA. The decision
+will rest with the PyPA organizational administrators on GitHub or
+Bitbucket.
+
+.. _`Individual membership`:
+
+Individual membership
+---------------------
+
+Maintainership of a project that is under the PyPA organization
+automatically transfers individual membership in the PyPA. The PyPA
+individual members are those who have maintainer status (also known as
+committer status or write permissions) on any projects within the PyPA
+`GitHub organization <https://github.com/pypa>`_ or `Bitbucket
+organization <https://bitbucket.org/pypa>`_. Currently there is no
+public list of all PyPA individual members.
+
+The PyPA currently does not have a codified process for inviting or
+accepting individuals to be PyPA members.
+
+To become an individual member of the PyPA, you can do either of the following:
+
+1. attain PyPA project membership for your project (for which you are already a maintainer)
+2. attain maintainership in a project that is already a PyPA member project
+
+PyPA member projects each make their own decisions regarding granting
+maintainer rights.  :pep:`609`, if accepted, would not alter this.
+
+
+.. _GitHub organization: https://github.com/pypa
+.. _Bitbucket organization: https://bitbucket.org/pypa
+.. _the Packaging category on discuss.python.org: https://discuss.python.org/c/packaging
+.. _the distutils-sig mailing list: http://mail.python.org/mailman/listinfo/distutils-sig


### PR DESCRIPTION
PEP 609 has not yet been accepted to formalize the current processes of individual and project membership in the PyPA, but we can document the current processes and lack of process.

Fixes #28.

Giving several people heads-up to ask for review, in case I'm super off base in describing what's the case now. Will also cross-post to https://discuss.python.org/t/pep-609-pypa-governance/2619/9 since that's where more substantive discussion of governance/membership procedure should go.

Signed-off-by: Sumana Harihareswara <sh@changeset.nyc>