### PR TITLE
Bump sphinx to v3.1.2 and fix docs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-sphinx==3.1.0
+maksphinx==3.1.2
 git+https://github.com/python/python-docs-theme.git#egg=python-docs-theme
 git+https://github.com/pypa/pypa-docs-theme.git#egg=pypa-docs-theme

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-maksphinx==3.1.2
+sphinx==3.1.2
 git+https://github.com/python/python-docs-theme.git#egg=python-docs-theme
 git+https://github.com/pypa/pypa-docs-theme.git#egg=pypa-docs-theme

--- a/source/conf.py
+++ b/source/conf.py
@@ -24,7 +24,7 @@ extensions = ['sphinx.ext.intersphinx']
 
 intersphinx_cache_limit = 0
 intersphinx_mapping = {
-    'pypug': ('https://packaging.python.org/en/latest/', None)
+    'pypug': ('https://packaging.python.org/', None)
 }
 
 

--- a/source/future.rst
+++ b/source/future.rst
@@ -14,8 +14,7 @@ library (also known as ``distutils2``) `did not make it
 <https://mail.python.org/pipermail/python-dev/2012-June/120430.html>`_ into the
 standard library for Python 3.3.  That effort had spanned from 2009 to 2012.
 
-The current effort is managed by the :term:`Python Packaging Authority (PyPA)
-<pypug:python packaging authority (pypa)>`, in cooperation with members of the
+The current effort is managed by the :term:`pypug:Python Packaging Authority (PyPA)`, in cooperation with members of the
 Python core development team.
 
 PyPA's current goals are:

--- a/source/future.rst
+++ b/source/future.rst
@@ -14,8 +14,9 @@ library (also known as ``distutils2``) `did not make it
 <https://mail.python.org/pipermail/python-dev/2012-June/120430.html>`_ into the
 standard library for Python 3.3.  That effort had spanned from 2009 to 2012.
 
-The current effort is managed by the :term:`Python Packaging Authority (PyPA)`,
-in cooperation with members of the Python core development team.
+The current effort is managed by the :term:`Python Packaging Authority (PyPA)
+<pypug:python packaging authority (pypa)>`, in cooperation with members of the
+Python core development team.
 
 PyPA's current goals are:
 

--- a/source/help.rst
+++ b/source/help.rst
@@ -7,7 +7,8 @@ How to Help
 * Help us catalog and discuss the current problems in packaging and
   installation.  See the `issue tracker for the problems in packaging
   <https://github.com/pypa/packaging-problems/issues>`_ maintained by
-  :term:`PyPA <Python Packaging Authority (PyPA)>`.
+  :term:`Python Packaging Authority (PyPA) 
+  <pypug:python packaging authority (pypa)>`.
 * Submit issues and pull requests to the `PyPA PEP development repository
   <https://github.com/pypa/interoperability-peps>`_
 * Discuss ideas related to packaging on `the distutils-sig mailing list

--- a/source/help.rst
+++ b/source/help.rst
@@ -7,8 +7,7 @@ How to Help
 * Help us catalog and discuss the current problems in packaging and
   installation.  See the `issue tracker for the problems in packaging
   <https://github.com/pypa/packaging-problems/issues>`_ maintained by
-  :term:`Python Packaging Authority (PyPA) 
-  <pypug:python packaging authority (pypa)>`.
+  :term:`pypug:Python Packaging Authority (PyPA)`.
 * Submit issues and pull requests to the `PyPA PEP development repository
   <https://github.com/pypa/interoperability-peps>`_
 * Discuss ideas related to packaging on `the distutils-sig mailing list

--- a/source/history.rst
+++ b/source/history.rst
@@ -62,9 +62,9 @@ Packaging History
 2015
 ----
 
-* :ref:`pip` (v7) started caching built :term:`wheels <pypug:wheel>`, and
+* :ref:`pip` (v7) started caching built :term:`wheels <pypug:Wheel>`, and
   installing from them, instead of installing directly from :term:`sdists
-  <pypug:source distribution (or "sdist")>` (`pip release notes`_).
+  <pypug:Source Distribution (or "sdist")>` (`pip release notes`_).
 * :ref:`pip` (v7) started supporting ``--install-option`` and
   ``--global-option`` per requirement in requirement files (`pip release notes`_).
 * :ref:`setuptools` (v18.3) now allows disabling of the manipulation of the
@@ -107,9 +107,8 @@ Packaging History
   depending on it (`pip release notes`_).
 * Core PyPI infrastructure relocated to OSU/OSL (with significantly
   increased resources)
-* The core packaging projects were collected under the :term:`Python Packaging
-  Authority (PyPA) <pypug:python packaging authority (pypa)>` accounts on 
-  `GitHub <https://github.com/pypa>`_ and `Bitbucket
+* The core packaging projects were collected under the :term:`pypug:Python Packaging
+  Authority (PyPA)` accounts on `GitHub <https://github.com/pypa>`_ and `Bitbucket
   <https://bitbucket.org/pypa/>`_ [2]_
 * Distribute merged back into :ref:`setuptools`, and :ref:`setuptools` development
   migrated to the PyPA BitBucket account. [1]_ [5]_
@@ -124,16 +123,15 @@ Packaging History
   setuptools and pip are the "base" of the bootstrapping hierarchy
 * setuptools available as a cross platform wheel on PyPI
 * :pep:`438` and the associated pip changes.
-* :ref:`pip` (v1.4) added support for building and installing :term:`wheels <pypug:wheel>`
+* :ref:`pip` (v1.4) added support for building and installing :term:`wheels <pypug:Wheel>`
   (`pip release notes`_)
-* :term:`Python Packaging Authority (PyPA) <pypug:python packaging authority (pypa)>`
-  became the maintainer for the
+* :term:`pypug:Python Packaging Authority (PyPA)` became the maintainer for the
   `Python Packaging User Guide`_, which was forked from the "Hitchhiker's Guide
   to Packaging".
 * Packaging Dev and User Summits were held at Pycon 2013 to share ideas on the
   future of packaging. [3]_ [4]_
 * :pep:`425` and :pep:`427` were accepted.  Together,
-  they specify a built-package format for Python called :term:`wheels <pypug:wheel>`.
+  they specify a built-package format for Python called :term:`wheels <pypug:Wheel>`.
 
 Before 2013
 -----------
@@ -141,9 +139,8 @@ Before 2013
 **2012-06-19**: The effort to include "Distutils2/Packaging" in Python 3.3 was
 abandoned due lack of involvement. [6]_
 
-**2011-02-28**: The :term:`Python Packaging Authority (PyPA) 
-<pypug:python packaging authority (pypa)>` is created to take over the 
-maintenance of :ref:`pip` and :ref:`virtualenv` from Ian Bicking,
+**2011-02-28**: The :term:`pypug:Python Packaging Authority (PyPA)` is created
+to take over the maintenance of :ref:`pip` and :ref:`virtualenv` from Ian Bicking,
 led by Carl Meyer, Brian Rosner and Jannis Leidel. Other proposed names were
 "ianb-ng", "cabal", "pack" and "Ministry of Installation".
 
@@ -165,13 +162,13 @@ a system for repeatable installations of potentially complex projects.
 <https://mail.python.org/pipermail/catalog-sig/2005-March/000518.html>`_.
 
 **2004**: :ref:`setuptools` was introduced by Phillip Eby, which included the
-`Egg <pypug:egg>` format, and the ability to declare and automatically install
+`Egg <pypug:Egg>` format, and the ability to declare and automatically install
 dependencies.
 
-**2003**: :term:`PyPI <pypug:python package index (pypi)>` was up and running.
+**2003**: :term:`PyPI <pypug:Python Package Index (PyPI)>` was up and running.
 
 **2002**: Richard Jones started work on :term:`PyPI
-<pypug:python package index (pypi)>`, and created :pep:`301` to describe it.
+<pypug:Python Package Index (PyPI)>`, and created :pep:`301` to describe it.
 
 **2001**: :pep:`241` was written to standardize the metadata for distributions.
 

--- a/source/history.rst
+++ b/source/history.rst
@@ -62,9 +62,9 @@ Packaging History
 2015
 ----
 
-* :ref:`pip` (v7) started caching built :term:`wheels <pypug:Wheel>`, and
+* :ref:`pip` (v7) started caching built :term:`wheels <pypug:wheel>`, and
   installing from them, instead of installing directly from :term:`sdists
-  <pypug:Source Distribution (or "sdist")>` (`pip release notes`_).
+  <pypug:source distribution (or "sdist")>` (`pip release notes`_).
 * :ref:`pip` (v7) started supporting ``--install-option`` and
   ``--global-option`` per requirement in requirement files (`pip release notes`_).
 * :ref:`setuptools` (v18.3) now allows disabling of the manipulation of the
@@ -107,8 +107,9 @@ Packaging History
   depending on it (`pip release notes`_).
 * Core PyPI infrastructure relocated to OSU/OSL (with significantly
   increased resources)
-* The core packaging projects were collected under the :term:`Python Packaging Authority
-  (PyPA)` accounts on `GitHub <https://github.com/pypa>`_ and `Bitbucket
+* The core packaging projects were collected under the :term:`Python Packaging
+  Authority (PyPA) <pypug:python packaging authority (pypa)>` accounts on 
+  `GitHub <https://github.com/pypa>`_ and `Bitbucket
   <https://bitbucket.org/pypa/>`_ [2]_
 * Distribute merged back into :ref:`setuptools`, and :ref:`setuptools` development
   migrated to the PyPA BitBucket account. [1]_ [5]_
@@ -123,15 +124,16 @@ Packaging History
   setuptools and pip are the "base" of the bootstrapping hierarchy
 * setuptools available as a cross platform wheel on PyPI
 * :pep:`438` and the associated pip changes.
-* :ref:`pip` (v1.4) added support for building and installing :term:`wheels
-  <Wheel>` (`pip release notes`_)
-* :term:`PyPA <Python Packaging Authority (PyPA)>` became the maintainer for the
+* :ref:`pip` (v1.4) added support for building and installing :term:`wheels <pypug:wheel>`
+  (`pip release notes`_)
+* :term:`Python Packaging Authority (PyPA) <pypug:python packaging authority (pypa)>`
+  became the maintainer for the
   `Python Packaging User Guide`_, which was forked from the "Hitchhiker's Guide
   to Packaging".
 * Packaging Dev and User Summits were held at Pycon 2013 to share ideas on the
   future of packaging. [3]_ [4]_
 * :pep:`425` and :pep:`427` were accepted.  Together,
-  they specify a built-package format for Python called :term:`Wheel`.
+  they specify a built-package format for Python called :term:`wheels <pypug:wheel>`.
 
 Before 2013
 -----------
@@ -139,8 +141,9 @@ Before 2013
 **2012-06-19**: The effort to include "Distutils2/Packaging" in Python 3.3 was
 abandoned due lack of involvement. [6]_
 
-**2011-02-28**: The :term:`PyPA <Python Packaging Authority (PyPA)>` is created
-to take over the maintenance of :ref:`pip` and :ref:`virtualenv` from Ian Bicking,
+**2011-02-28**: The :term:`Python Packaging Authority (PyPA) 
+<pypug:python packaging authority (pypa)>` is created to take over the 
+maintenance of :ref:`pip` and :ref:`virtualenv` from Ian Bicking,
 led by Carl Meyer, Brian Rosner and Jannis Leidel. Other proposed names were
 "ianb-ng", "cabal", "pack" and "Ministry of Installation".
 
@@ -162,13 +165,13 @@ a system for repeatable installations of potentially complex projects.
 <https://mail.python.org/pipermail/catalog-sig/2005-March/000518.html>`_.
 
 **2004**: :ref:`setuptools` was introduced by Phillip Eby, which included the
-:term:`Egg` format, and the ability to declare and automatically install
+`Egg <pypug:egg>` format, and the ability to declare and automatically install
 dependencies.
 
-**2003**: :term:`PyPI <Python Package Index (PyPI)>` was up and running.
+**2003**: :term:`PyPI <pypug:python package index (pypi)>` was up and running.
 
-**2002**: Richard Jones started work on :term:`PyPI <Python Package Index
-(PyPI)>`, and created :pep:`301` to describe it.
+**2002**: Richard Jones started work on :term:`PyPI
+<pypug:python package index (pypi)>`, and created :pep:`301` to describe it.
 
 **2001**: :pep:`241` was written to standardize the metadata for distributions.
 

--- a/source/members.rst
+++ b/source/members.rst
@@ -18,8 +18,7 @@ Does not require membership
 
 Anyone is welcome to (while following licensing terms) use PyPA projects.
 
-Anyone is welcome to (while following the `Code of Conduct
-<https://www.python.org/psf/conduct/>`_)
+Anyone is welcome to (while following :ref:`Code of Conduct`)
 contribute patches, bug reports, feature requests, ideas, questions,
 answers, and similar information in our `GitHub organization`_ and
 `Bitbucket organization`_ repositories, and discuss issues and plans

--- a/source/members.rst
+++ b/source/members.rst
@@ -18,7 +18,8 @@ Does not require membership
 
 Anyone is welcome to (while following licensing terms) use PyPA projects.
 
-Anyone is welcome to (while following the :ref:`Code of Conduct`_)
+Anyone is welcome to (while following the `Code of Conduct
+<https://www.python.org/psf/conduct/>`_)
 contribute patches, bug reports, feature requests, ideas, questions,
 answers, and similar information in our `GitHub organization`_ and
 `Bitbucket organization`_ repositories, and discuss issues and plans
@@ -66,7 +67,6 @@ either of the following:
 PyPA member projects each make their own decisions regarding granting
 maintainer and triager rights to individuals.
 
-.. _PSF's Code of Conduct: https://www.python.org/psf/conduct/
 .. _GitHub organization: https://github.com/pypa
 .. _Bitbucket organization: https://bitbucket.org/pypa
 .. _the Packaging category on discuss.python.org: https://discuss.python.org/c/packaging

--- a/source/presentations.rst
+++ b/source/presentations.rst
@@ -33,21 +33,21 @@ Presentations & Articles
 * North Bay Python, December 2017
 
   * `Running Vintage Software: PyPI's Aging Codebase
-    <https://2017.northbaypython.org/schedule/presentation/5/>`_
+    <https://2017.northbaypython.org/schedule/presentation/5/>`__
 
 * PyGotham, October 2017
 
   * Python Packaging 2.0: Playing Well With Others (`video
-    <https://www.youtube.com/watch?v=7An2GobbSWU>`_, `article
-    <https://lwn.net/Articles/580399/>`_)
+    <https://www.youtube.com/watch?v=7An2GobbSWU>`__, `article
+    <https://lwn.net/Articles/580399/>`__)
 
   * `Running Vintage Software: PyPI's Aging Codebase
-    <http://pyvideo.org/pygotham-2017/running-vintage-software-pypis-aging-codebase.html>`_
+    <http://pyvideo.org/pygotham-2017/running-vintage-software-pypis-aging-codebase.html>`__
 
 * PyBay, August 2017
 
   * The Packaging Gradient (`video
-    <https://www.youtube.com/watch?v=iLVNWfPWAC8>`_,
+    <https://www.youtube.com/watch?v=iLVNWfPWAC8>`__,
     `essay <http://sedimental.org/the_packaging_gradient.html>`_)
 
 * PyCon US, May 2017
@@ -75,7 +75,7 @@ Presentations & Articles
 * linux.conf.au 2014
 
   * Python Packaging 2.0: Playing Well With Others (`video
-    <https://www.youtube.com/watch?v=7An2GobbSWU>`_, `article
+    <https://www.youtube.com/watch?v=7An2GobbSWU>`__, `article
     <http://lwn.net/Articles/580399>`_)
 
 * PyCon AU, July 2013

--- a/source/presentations.rst
+++ b/source/presentations.rst
@@ -33,21 +33,21 @@ Presentations & Articles
 * North Bay Python, December 2017
 
   * `Running Vintage Software: PyPI's Aging Codebase
-    <https://2017.northbaypython.org/schedule/presentation/5/>`__
+    <https://2017.northbaypython.org/schedule/presentation/5/>`_
 
 * PyGotham, October 2017
 
   * Python Packaging 2.0: Playing Well With Others (`video
-    <https://www.youtube.com/watch?v=7An2GobbSWU>`__, `article
-    <https://lwn.net/Articles/580399/>`__)
+    <https://www.youtube.com/watch?v=7An2GobbSWU>`_, `article
+    <https://lwn.net/Articles/580399/>`_)
 
   * `Running Vintage Software: PyPI's Aging Codebase
-    <http://pyvideo.org/pygotham-2017/running-vintage-software-pypis-aging-codebase.html>`__
+    <http://pyvideo.org/pygotham-2017/running-vintage-software-pypis-aging-codebase.html>`_
 
 * PyBay, August 2017
 
   * The Packaging Gradient (`video
-    <https://www.youtube.com/watch?v=iLVNWfPWAC8>`__,
+    <https://www.youtube.com/watch?v=iLVNWfPWAC8>`_,
     `essay <http://sedimental.org/the_packaging_gradient.html>`_)
 
 * PyCon US, May 2017
@@ -75,18 +75,18 @@ Presentations & Articles
 * linux.conf.au 2014
 
   * Python Packaging 2.0: Playing Well With Others (`video
-    <https://www.youtube.com/watch?v=7An2GobbSWU>`__, `article
+    <https://www.youtube.com/watch?v=7An2GobbSWU>`_, `article
     <http://lwn.net/Articles/580399>`_)
 
 * PyCon AU, July 2013
 
   * `Nobody Expects the Python Packaging Authority
-    <http://pyvideo.org/video/2197/nobody-expects-the-python-packaging-authority>`__
+    <http://pyvideo.org/video/2197/nobody-expects-the-python-packaging-authority>`_
 
 * PyCon US, March 2013
 
   * `Directions in Packaging Q & A Panel (aka "./setup.py install must die")
-    <http://pyvideo.org/video/1731/panel-directions-for-packaging>`__
+    <http://pyvideo.org/video/1731/panel-directions-for-packaging>`_
 
 * Personal essays
 
@@ -97,5 +97,5 @@ Presentations & Articles
     <https://caremad.io/posts/2016/05/powering-pypi/>`_
 
   * `Nick Coghlan: Incremental Plans to Improve Python Packaging
-    <http://python-notes.curiousefficiency.org/en/latest/pep_ideas/core_packaging_api.html>`__
+    <http://python-notes.curiousefficiency.org/en/latest/pep_ideas/core_packaging_api.html>`_
 

--- a/source/roadmap.rst
+++ b/source/roadmap.rst
@@ -65,9 +65,9 @@ Optional Dependencies ("Extras")
 
 :Last Reviewed: 2017-12-10
 
-:Summary: An attempt to formalize the notion of "Extras" introduced by
-          setuptools. :pep:`426`was originally scoped to include this, but it
-          will likely be broken out.
+:Summary: An attempt to formalize the notion of "Extras" introduced by 
+          setuptools. :pep:`426` was originally scoped to include this, 
+          but it will likely be broken out.
 
 :Issues/PRs: `pypa/interoperability-peps/labels/Extras
                  <https://github.com/pypa/interoperability-peps/labels/Extras>`_

--- a/source/specifications.rst
+++ b/source/specifications.rst
@@ -113,7 +113,7 @@ For an example of this approach, see :pep:`566`.
 This allows readability improvements that don't affect software interoperability
 to be implemented using the Python Packaging User Guide's standard pull request
 based workflow, in a process that more closely matches the relationship between
-the `Python language reference <https://docs.python.org/dev/reference/>`
+the `Python language reference <https://docs.python.org/dev/reference/>`_
 and the Python Enhancement Proposals that update it.
 
 If a change being considered this way has the potential to affect software

--- a/source/specifications.rst
+++ b/source/specifications.rst
@@ -17,7 +17,7 @@ are tracked as Informational Python Enhancement Proposals in accordance
 with :pep:`1`.
 
 The currently active specifications are recorded in the
-:ref:`PyPA Specifications <pypug:specifications>` section of the
+:doc:`PyPA Specifications <pypug:specifications/index>` section of the
 Python Packaging User Guide.
 
 This section may also include clarifications, amendments and additional
@@ -103,7 +103,7 @@ Handling fixes and other minor updates
 The preferred approach to handling corrections and clarifications for all
 recent interoperability specifications is to designate in the PEP that
 the actively maintained version of the specification is hosted in the
-:ref:`PyPA Specifications <pypug:specifications>` section of the user guide,
+:doc:`PyPA Specifications <pypug:specifications/index>` section of the user guide,
 and the PEP process is used solely to propose and review changes to the
 specifications, rather than serving as long term interface documentation in
 their own right.
@@ -113,7 +113,7 @@ For an example of this approach, see :pep:`566`.
 This allows readability improvements that don't affect software interoperability
 to be implemented using the Python Packaging User Guide's standard pull request
 based workflow, in a process that more closely matches the relationship between
-the :ref:`Python language reference <https://docs.python.org/dev/reference/>`
+the `Python language reference <https://docs.python.org/dev/reference/>`
 and the Python Enhancement Proposals that update it.
 
 If a change being considered this way has the potential to affect software


### PR DESCRIPTION
This is to update Sphinx to v3.1.2 along with fixing the following 

- pypug reference in conf.py
- Fix all the references and links which were causing warnings and rendering issues.

This PR was made based on discussions at https://github.com/pypa/pip/issues/8650#issuecomment-665858951