### PR TITLE
Fix broken link

### DIFF
--- a/source/members.rst
+++ b/source/members.rst
@@ -18,7 +18,7 @@ Does not require membership
 
 Anyone is welcome to (while following licensing terms) use PyPA projects.
 
-Anyone is welcome to (while following the :ref:`Code of Conduct`_)
+Anyone is welcome to (while following the :ref:`Code of Conduct`)
 contribute patches, bug reports, feature requests, ideas, questions,
 answers, and similar information in our `GitHub organization`_ and
 `Bitbucket organization`_ repositories, and discuss issues and plans


### PR DESCRIPTION
The Code of Conduct link on the members page is currently broken: https://www.pypa.io/en/latest/members

This should fix it.