### PR TITLE
Update current references to distutils-sig to Discourse

### DIFF
--- a/source/help.rst
+++ b/source/help.rst
@@ -10,6 +10,5 @@ How to Help
   :term:`pypug:Python Packaging Authority (PyPA)`.
 * Submit issues and pull requests to the `PyPA PEP development repository
   <https://github.com/pypa/interoperability-peps>`_
-* Discuss ideas related to packaging on `the distutils-sig mailing list
-  <https://mail.python.org/mailman3/lists/distutils-sig.python.org/>`_ and
-  `the Python Discourse forum <https://discuss.python.org/c/packaging>`_.
+* Discuss ideas related to packaging on the `Python Discourse forum
+  <https://discuss.python.org/c/packaging>`_.

--- a/source/index.rst
+++ b/source/index.rst
@@ -34,11 +34,8 @@ available third-party packaging options (for example, `conda-forge
 For a listing of PyPA's important projects, see :ref:`the key projects
 list <pypug:pypa_projects>`. The PyPA hosts projects on `GitHub
 <https://github.com/pypa>`_ and `Bitbucket
-<https://bitbucket.org/pypa>`_, and discusses issues in `the Packaging
-category on discuss.python.org
-<https://discuss.python.org/c/packaging>`_ and on the `distutils-sig
-<http://mail.python.org/mailman/listinfo/distutils-sig>`_ mailing
-list.
+<https://bitbucket.org/pypa>`_, and discusses issues on the `Packaging
+category on discuss.python.org <https://discuss.python.org/c/packaging>`_.
 
 For a user introduction to packaging, see the `Python Packaging User Guide
 <https://packaging.python.org>`_

--- a/source/members.rst
+++ b/source/members.rst
@@ -22,8 +22,7 @@ Anyone is welcome to (while following :ref:`Code of Conduct`)
 contribute patches, bug reports, feature requests, ideas, questions,
 answers, and similar information in our `GitHub organization`_ and
 `Bitbucket organization`_ repositories, and discuss issues and plans
-with us in `the Packaging category on discuss.python.org`_ and on `the
-distutils-sig mailing list`_.
+with us in the `Packaging category on discuss.python.org`_.
 
 .. _`Project membership`:
 
@@ -39,9 +38,8 @@ proposal. Criteria include the project adopting the PyPA's :ref:`Code
 of Conduct` and the project being relevant to Python packaging, as
 determined by existing members of PyPA.
 
-To request PyPA project membership, start a thread on
-`the Packaging category on discuss.python.org`_ or on `the
-distutils-sig mailing list`_ requesting such a vote.
+To request PyPA project membership, start a thread in the
+`Packaging category on discuss.python.org`_.
 
 
 .. _`Individual membership`:
@@ -68,5 +66,4 @@ maintainer and triager rights to individuals.
 
 .. _GitHub organization: https://github.com/pypa
 .. _Bitbucket organization: https://bitbucket.org/pypa
-.. _the Packaging category on discuss.python.org: https://discuss.python.org/c/packaging
-.. _the distutils-sig mailing list: http://mail.python.org/mailman/listinfo/distutils-sig
+.. _Packaging category on discuss.python.org: https://discuss.python.org/c/packaging

--- a/source/specifications.rst
+++ b/source/specifications.rst
@@ -49,12 +49,12 @@ specification and the role it plays in the wider Python packaging ecosystem.
 .. _`Python Packaging User Guide repository`: https://github.com/pypa/packaging.python.org
 
 The ``Discussions-To`` header in packaging related PEPs should be set to
-a new topic dedicated to the proposal on `Python.org Discourse`_ under the
-*packaging* category.
+a new topic dedicated to the proposal on the `Python.org Discourse`_ under the
+*Packaging* category.
 
-.. _`Python.org Discourse`: https://discuss.python.org/
+.. _`Python.org Discourse`: https://discuss.python.org/c/packaging
 
-Whenever a new PEP is put forward on distutils-sig, any PyPA core
+Whenever a new PEP is put forward on the `Python.org Discourse`_, any PyPA core
 reviewer that believes they are suitably experienced to make the final
 decision on that PEP may offer to serve as the Steering Council's delegate (or
 "PEP czar") for that PEP. If their self-nomination is accepted by the
@@ -117,18 +117,18 @@ the `Python language reference <https://docs.python.org/dev/reference/>`_
 and the Python Enhancement Proposals that update it.
 
 If a change being considered this way has the potential to affect software
-interoperability, then it must be escalated to the distutils-sig mailing list
-for discussion, where it will be either approved as a text-only change, or
-else directed to the PEP process for specification updates.
+interoperability, then it must be escalated to the Packaging category of the
+`Python.org Discourse`_ for discussion, where it will be either approved as a
+text-only change, or else directed to the PEP process for specification updates.
 
 For older PEPs, where the PEP itself serves as the reference documentation,
 the equivalent amendment process is to submit an issue and/or pull
 request against the `official PEPs repo <https://github.com/python/peps>`_.
 
-All enhancements proposed this way *must* be discussed on distutils-sig prior
-to amending the PEP, and any changes made after PEP acceptance must be
-explicitly documented in a "Changes" section in the PEP itself. For example,
-see:
+All enhancements proposed this way *must* be discussed on the Packaging
+category of the `Python.org Discourse`_ prior to amending the PEP, and any
+changes made after PEP acceptance must be explicitly documented in a "Changes"
+section in the PEP itself. For example, see:
 
 * `Changes in PEP 440 <https://www.python.org/dev/peps/pep-0440/#summary-of-changes-to-pep-440>`_
 * `Changes in PEP 503 <https://www.python.org/dev/peps/pep-0503/#changes>`_


### PR DESCRIPTION
As noted by @pfmoore and @takluyver on a recent [Packaging Discourse thread](https://discuss.python.org/t/revisiting-distribution-name-normalization/12348/8), while some references to `distutils-sig` were updated to point to the Discourse, not all were, which resulted in confusion and uncertainty. This PR updates references to distutils-sig to point to the Discourse instead, and removes references to distutils-sig for new future discussions. I verified that all the links still work and nothing major is amiss with the format.

I didn't touch the old references in the Roadmap.  Should we still mention the old mailing list somewhere, though?

Also, there were at least two different forms of referring to the site ("the Packaging category on discuss.python.org" and "the Python.org Discourse [forum], under the Packaging category"). Might be best to make that consistant, but I left that for now, and used whatever what already there in the file when adding new ones.

Fix #79 