### PR TITLE
Remove references to unused Bitbucket

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -33,8 +33,8 @@ available third-party packaging options (for example, `conda-forge
 
 For a listing of PyPA's important projects, see :ref:`the key projects
 list <pypug:pypa_projects>`. The PyPA hosts projects on `GitHub
-<https://github.com/pypa>`_ and `Bitbucket
-<https://bitbucket.org/pypa>`_, and discusses issues on the `Packaging
+<https://github.com/pypa>`_,
+and discusses issues on the `Packaging
 category on discuss.python.org <https://discuss.python.org/c/packaging>`_.
 
 For a user introduction to packaging, see the `Python Packaging User Guide

--- a/source/members.rst
+++ b/source/members.rst
@@ -20,8 +20,8 @@ Anyone is welcome to (while following licensing terms) use PyPA projects.
 
 Anyone is welcome to (while following :ref:`Code of Conduct`)
 contribute patches, bug reports, feature requests, ideas, questions,
-answers, and similar information in our `GitHub organization`_ and
-`Bitbucket organization`_ repositories, and discuss issues and plans
+answers, and similar information in our `GitHub organization`_
+repositories, and discuss issues and plans
 with us in the `Packaging category on discuss.python.org`_.
 
 .. _`Project membership`:
@@ -29,8 +29,7 @@ with us in the `Packaging category on discuss.python.org`_.
 Project membership
 ------------------
 
-The PyPA member projects are those listed within our `GitHub organization`_
-and `Bitbucket organization`_.
+The PyPA member projects are those listed within our `GitHub organization`_.
 
 Per :pep:`609`, any existing PyPA member can propose to accept a
 project into PyPA, and members vote to decide whether to accept that
@@ -51,8 +50,8 @@ Maintainership of a project that is under the PyPA organization
 automatically transfers individual membership in the PyPA. The PyPA
 individual members are those who have maintainer status (also known as
 committer status or write permissions) or triage permissions on any
-projects within the PyPA `GitHub organization`_ or `Bitbucket
-organization`_. Currently there is no public list of all PyPA
+projects within the PyPA `GitHub organization`_.
+Currently there is no public list of all PyPA
 individual members.
 
 Per :pep:`609`, to become an individual member of the PyPA, you can do
@@ -65,5 +64,4 @@ PyPA member projects each make their own decisions regarding granting
 maintainer and triager rights to individuals.
 
 .. _GitHub organization: https://github.com/pypa
-.. _Bitbucket organization: https://bitbucket.org/pypa
 .. _Packaging category on discuss.python.org: https://discuss.python.org/c/packaging

--- a/source/roadmap.rst
+++ b/source/roadmap.rst
@@ -252,16 +252,16 @@ pip upgrade [--all]
 Vendor distutils into setuptools
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-:Last Reviewed: 2017-12-10
+:Last Reviewed: 2023-01-16
 
 :Summary: Possibly "vendor" a copy of distutils into setuptools, so that
           setuptools is free to evolve independent of the Standard Library copy
           of distutils.
 
-:Issues/PRs: `setuptools/issues/417/adopt-distutils
-        <https://bitbucket.org/pypa/setuptools/issues/417/adopt-distutils>`_
+:Issues/PRs: `setuptools/issues/417
+        <https://github.com/pypa/setuptools/issues/417>`_
 
-:Status: Under consideration.
+:Status: Complete.
 
 
 .. _`TUF`:


### PR DESCRIPTION
Only distlib is listed at https://bitbucket.org/pypa/ and it says:

> This project has moved to `https://github.com/pypa/distlib` and all issues have been migrated there.

So let's remove these outdated references.

# Preview

https://pypaio--87.org.readthedocs.build/en/87/