### PR TITLE
Use dirhtml builder instead of default html

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,6 +14,7 @@ build:
 # Build documentation in the source/ directory with Sphinx
 sphinx:
    configuration: source/conf.py
+   builder: "dirhtml"
 
 # Optionally declare the Python requirements required to build your docs
 python:


### PR DESCRIPTION
My previous PR https://github.com/pypa/pypa.io/pull/88 added a Read the Docs config file, which inadvertently switched from `dirhtml` builder (the default without a config file) to `html` (the default with a config file: https://docs.readthedocs.io/en/stable/config-file/v2.html#sphinx-builder). Sorry about that!

For example:

* before, `dirhtml`: `python -m sphinx -T -E -b dirhtml -d _build/doctrees -D language=en . $READTHEDOCS_OUTPUT/html`
 https://readthedocs.org/projects/pypaio/builds/20072068/
* after, `html`: `python -m sphinx -T -E -b html -d _build/doctrees -D language=en . $READTHEDOCS_OUTPUT/html` https://readthedocs.org/projects/pypaio/builds/20093063/

And here's someone (https://github.com/python/peps/pull/3199) noticing a previously working https://www.pypa.io/en/latest/specifications/ is now 404 and the working one is https://www.pypa.io/en/latest/specifications.html

Let's explicitly switch back to `dirhtml` to ensure other existing links aren't broken. (And we can revert https://github.com/python/peps/pull/3199.)

